### PR TITLE
chore: upgrade to Go 1.24 and fix minor issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/api/v1alpha1/modelvalidation_types.go
+++ b/api/v1alpha1/modelvalidation_types.go
@@ -173,7 +173,6 @@ type ModelValidationStatus struct {
 // +kubebuilder:printcolumn:name="Injected Pods",type=integer,JSONPath=`.status.injectedPodCount`
 // +kubebuilder:printcolumn:name="Uninjected Pods",type=integer,JSONPath=`.status.uninjectedPodCount`
 // +kubebuilder:printcolumn:name="Orphaned Pods",type=integer,JSONPath=`.status.orphanedPodCount`
-// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="Model Path",type="string",JSONPath=".spec.model.path"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ModelValidation struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -212,7 +212,7 @@ func main() {
 			filepath.Join(metricsCertPath, metricsCertKey),
 		)
 		if err != nil {
-			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
+			setupLog.Error(err, "Failed to initialize metrics certificate watcher")
 			os.Exit(1)
 		}
 

--- a/config/crd/bases/ml.sigstore.dev_modelvalidations.yaml
+++ b/config/crd/bases/ml.sigstore.dev_modelvalidations.yaml
@@ -29,9 +29,6 @@ spec:
     - jsonPath: .status.orphanedPodCount
       name: Orphaned Pods
       type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     - jsonPath: .spec.model.path
       name: Model Path
       type: string

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/sigstore/model-validation-operator
 
-go 1.23.0
+go 1.24.0
 
-godebug default=go1.23
+godebug default=go1.24
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
- Update Dockerfile and go.mod to Go 1.24 (fixes Dependabot CI failures)
- Remove duplicate Age PrintColumn in CRD
- Fix error log message in metrics cert watcher